### PR TITLE
Display error message from signing job

### DIFF
--- a/src/actionCreators/index.js
+++ b/src/actionCreators/index.js
@@ -25,6 +25,7 @@ import {
   jobCreated,
   jobCreating,
   jobCreationFailed,
+  jobFailed,
   jobProcessing,
 } from '../actions';
 import implicitAuthManager from '../auth';
@@ -104,17 +105,15 @@ const checkJobStatus = (jobId, dispatch) => {
         setTimeout(() => {
           checkJobStatus(jobId, dispatch);
         }, apiPollTimeout);
-
-        return;
-      }
-
-      if (res.status === 200 && res.data.status === 'Completed') {
+      } else if (res.status === 200 && res.data.status === 'Completed') {
         dispatch(jobCompleted(res.data));
+      } else if (res.status === 200 && res.data.status === 'Failed') {
+        dispatch(jobFailed(res.data));
       }
     })
     .catch(err => {
       let message = 'Unable to check job status';
-      const code = err.response.status;
+      const code = typeof err.response.status != 'undefined' ? err.response.status : 0;
       if (err.response.data.error) {
         message = err.response.data.error;
       }

--- a/src/actionCreators/index.js
+++ b/src/actionCreators/index.js
@@ -34,7 +34,6 @@ import { API } from '../constants';
 const axi = axios.create({
   baseURL: API.BASE_URL(),
 });
-
 const apiPollTimeout = 3000;
 const maxStatusCheckCount = (120 * 1000) / apiPollTimeout;
 let statusCheckCount = 0;
@@ -72,12 +71,12 @@ export const createSigningJob = (files, platform) => dispatch => {
     .catch(err => {
       dispatch(jobCreationFailed());
 
+      const code = typeof err.response.status !== 'undefined' ? err.response.status : 0;
       let message = 'Unable to create signing job';
-      const code = err.response.status;
       if (err.response.data.error) {
         message = err.response.data.error;
       }
-      console.log(`error = ${message}, code = ${code}`);
+
       dispatch(apiRequestFailed(message, code));
     });
 };

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -68,7 +68,7 @@ export const jobCompleted = data => {
 export const jobFailed = data => {
   return {
     type: JOB_STATUS.FAILED,
-    url: data.url,
+    message: data.statusMessage,
   };
 };
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -65,6 +65,13 @@ export const jobCompleted = data => {
   };
 };
 
+export const jobFailed = data => {
+  return {
+    type: JOB_STATUS.FAILED,
+    url: data.url,
+  };
+};
+
 export const apiRequestFailed = (message, code) => {
   return {
     type: API_ERROR.JOB_STATUS_CHECK_FAILED,

--- a/src/components/JobStatusIndicator/JobStatusIndicator.js
+++ b/src/components/JobStatusIndicator/JobStatusIndicator.js
@@ -82,7 +82,6 @@ const JobStatusIndicator = ({ job }) => {
         </div>
       );
     case JOB_STATUS.FAILED:
-      console.log('xxx', job);
       return <div className="job-status">Failed. {job.message} </div>;
     default:
       return <div />;

--- a/src/components/JobStatusIndicator/JobStatusIndicator.js
+++ b/src/components/JobStatusIndicator/JobStatusIndicator.js
@@ -18,11 +18,11 @@
 // Created by Jason Leach on 2018-09-04.
 //
 
-import React from 'react';
-import PropTypes from 'prop-types';
-import { MoonLoader } from 'react-spinners';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { css } from 'react-emotion';
+import { MoonLoader } from 'react-spinners';
 import { JOB_STATUS } from '../../constants';
 import './JobStatusIndicator.css';
 
@@ -81,6 +81,8 @@ const JobStatusIndicator = ({ job }) => {
           &nbsp;&nbsp; {deliveryUrlForJob(job)}
         </div>
       );
+    case JOB_STATUS.FAILED:
+      return <div className="job-status">Failed</div>;
     default:
       return <div />;
   }

--- a/src/components/JobStatusIndicator/JobStatusIndicator.js
+++ b/src/components/JobStatusIndicator/JobStatusIndicator.js
@@ -82,7 +82,8 @@ const JobStatusIndicator = ({ job }) => {
         </div>
       );
     case JOB_STATUS.FAILED:
-      return <div className="job-status">Failed</div>;
+      console.log('xxx', job);
+      return <div className="job-status">Failed. {job.message} </div>;
     default:
       return <div />;
   }

--- a/src/constants.js
+++ b/src/constants.js
@@ -32,7 +32,10 @@ export const JOB_STATUS = {
 };
 
 export const API = {
-  BASE_URL: () => `${window.location.origin}/api/v1/` || 'http://localhost:8089',
+  BASE_URL: () =>
+    process.env.NODE_ENV === 'development'
+      ? 'http://localhost:8089/api/v1/'
+      : `${window.location.origin}/api/v1/`,
   CREATE_JOB: platformId => `sign?platform=${platformId}`,
   CHECK_JOB_STATUS: jobId => `job/${jobId}/status`,
 };

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -39,24 +39,28 @@ const job = (state = {}, action) => {
     case JOB_STATUS.CREATING:
       return {
         status: JOB_STATUS.CREATING,
+        message: undefined,
         jobId: undefined,
         url: undefined,
       };
     case JOB_STATUS.CREATED:
       return {
         status: JOB_STATUS.CREATED,
+        message: undefined,
         jobId: action.jobId,
         url: undefined,
       };
     case JOB_STATUS.FAILED:
       return {
         status: JOB_STATUS.FAILED,
+        message: action.message,
         jobId: undefined,
         url: undefined,
       };
     case JOB_STATUS.PROCESSING:
       return {
         status: JOB_STATUS.PROCESSING,
+        message: undefined,
         jobId: state.jobId,
         url: undefined,
       };


### PR DESCRIPTION
When a signing job fails the associated error message returned by the API is displayed to the user. This is, hopefully, to give them better context and the ability to fix the issue and re-submit the job.