### PR TITLE
Changed tab title from 'React App' to 'Secure Sign'

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Secure Sign</title>
   </head>
   <body>
     <noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Secure Sign",
+  "name": "BC Gov Secure Sign for Mobile Apps",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -20,7 +20,7 @@ export class App extends Component {
   }
 
   componentDidMount = () => {
-    document.title = "Secure Sign";
+    // document.title = "Secure Sign";
     implicitAuthManager.registerHooks({
       onAuthenticateSuccess: () => this.props.login(),
       onAuthenticateFail: () => this.props.logout(),

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -20,6 +20,7 @@ export class App extends Component {
   }
 
   componentDidMount = () => {
+    document.title = "Secure Sign";
     implicitAuthManager.registerHooks({
       onAuthenticateSuccess: () => this.props.login(),
       onAuthenticateFail: () => this.props.logout(),

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -20,7 +20,6 @@ export class App extends Component {
   }
 
   componentDidMount = () => {
-    // document.title = "Secure Sign";
     implicitAuthManager.registerHooks({
       onAuthenticateSuccess: () => this.props.login(),
       onAuthenticateFail: () => this.props.logout(),


### PR DESCRIPTION
The tabs in Secure Sign were titled "React App", in this PR, we changed them to "Secure Sign" in index.html and manifest.json.