### PR TITLE
UX Enhancements on Signing Tool Page

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom --coverage",
     "test:watch": "react-scripts test --watch --env=jsdom",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "test:lint": "eslint src/"
   },
   "devDependencies": {
     "enzyme": "^3.7.0",

--- a/src/__tests__/components/Toggle.test.js
+++ b/src/__tests__/components/Toggle.test.js
@@ -13,7 +13,7 @@ describe('Toggle Component', () => {
     const wrapper = shallow(<Toggle title="test toggle" children={<div>test toggle</div>} />);
     expect(wrapper.state('toggled')).toBe(false);
     wrapper
-      .find('.toggle-icon')
+      .find('.toggle-header')
       .first()
       .simulate('click');
     expect(wrapper.state('toggled')).toBe(true);
@@ -23,7 +23,10 @@ describe('Toggle Component', () => {
     const wrapper = shallow(<Toggle title="test toggle" children={<div>test toggle</div>} />);
     const button0 = wrapper.find('.toggle-icon').first();
     expect(button0.prop('icon')).toEqual(faArrowDown);
-    button0.simulate('click');
+    wrapper
+      .find('.toggle-header')
+      .first()
+      .simulate('click');
     const button1 = wrapper.find('.toggle-icon').first();
     expect(button1.prop('icon')).toEqual(faArrowUp);
   });

--- a/src/__tests__/components/__snapshots__/Toggle.test.js.snap
+++ b/src/__tests__/components/__snapshots__/Toggle.test.js.snap
@@ -26,6 +26,7 @@ ShallowWrapper {
       "children": Array [
         <div
           className="toggle-header"
+          onClick={[Function]}
         >
           <div>
             test toggle
@@ -52,7 +53,6 @@ ShallowWrapper {
               inverse={false}
               listItem={false}
               mask={null}
-              onClick={[Function]}
               pull={null}
               pulse={false}
               rotation={null}
@@ -105,7 +105,6 @@ ShallowWrapper {
                 inverse={false}
                 listItem={false}
                 mask={null}
-                onClick={[Function]}
                 pull={null}
                 pulse={false}
                 rotation={null}
@@ -118,6 +117,7 @@ ShallowWrapper {
             </div>,
           ],
           "className": "toggle-header",
+          "onClick": [Function],
         },
         "ref": null,
         "rendered": Array [
@@ -158,7 +158,6 @@ ShallowWrapper {
                 inverse={false}
                 listItem={false}
                 mask={null}
-                onClick={[Function]}
                 pull={null}
                 pulse={false}
                 rotation={null}
@@ -193,7 +192,6 @@ ShallowWrapper {
                 "inverse": false,
                 "listItem": false,
                 "mask": null,
-                "onClick": [Function],
                 "pull": null,
                 "pulse": false,
                 "rotation": null,
@@ -247,6 +245,7 @@ ShallowWrapper {
         "children": Array [
           <div
             className="toggle-header"
+            onClick={[Function]}
           >
             <div>
               test toggle
@@ -273,7 +272,6 @@ ShallowWrapper {
                 inverse={false}
                 listItem={false}
                 mask={null}
-                onClick={[Function]}
                 pull={null}
                 pulse={false}
                 rotation={null}
@@ -326,7 +324,6 @@ ShallowWrapper {
                   inverse={false}
                   listItem={false}
                   mask={null}
-                  onClick={[Function]}
                   pull={null}
                   pulse={false}
                   rotation={null}
@@ -339,6 +336,7 @@ ShallowWrapper {
               </div>,
             ],
             "className": "toggle-header",
+            "onClick": [Function],
           },
           "ref": null,
           "rendered": Array [
@@ -379,7 +377,6 @@ ShallowWrapper {
                   inverse={false}
                   listItem={false}
                   mask={null}
-                  onClick={[Function]}
                   pull={null}
                   pulse={false}
                   rotation={null}
@@ -414,7 +411,6 @@ ShallowWrapper {
                   "inverse": false,
                   "listItem": false,
                   "mask": null,
-                  "onClick": [Function],
                   "pull": null,
                   "pulse": false,
                   "rotation": null,

--- a/src/components/Toggle/Toggle.css
+++ b/src/components/Toggle/Toggle.css
@@ -16,4 +16,5 @@
   font-size: 17px;
   display: flex;
   justify-content: space-between;
+  cursor: pointer;
 }

--- a/src/components/Toggle/Toggle.js
+++ b/src/components/Toggle/Toggle.js
@@ -23,24 +23,20 @@ class Toggle extends Component {
       <FontAwesomeIcon
         icon={faArrowUp}
         className="toggle-icon"
-        onClick={() => {
-          this.toggledHandler(false);
-        }}
       />
     ) : (
       <FontAwesomeIcon
         icon={faArrowDown}
         className="toggle-icon"
-        onClick={() => {
-          this.toggledHandler(true);
-        }}
       />
     );
     const { children, title } = this.props;
 
     return (
       <div className={`instruction ${toggleClass}`}>
-        <div className="toggle-header">
+        <div className="toggle-header" onClick={() => {
+          this.toggledHandler(!this.state.toggled);
+        }}>
           <div>{title}</div>
           <div>{toggleIcon}</div>
         </div>

--- a/src/components/Toggle/Toggle.js
+++ b/src/components/Toggle/Toggle.js
@@ -20,23 +20,20 @@ class Toggle extends Component {
   render() {
     const toggleClass = this.state.toggled ? 'on' : '';
     const toggleIcon = this.state.toggled ? (
-      <FontAwesomeIcon
-        icon={faArrowUp}
-        className="toggle-icon"
-      />
+      <FontAwesomeIcon icon={faArrowUp} className="toggle-icon" />
     ) : (
-      <FontAwesomeIcon
-        icon={faArrowDown}
-        className="toggle-icon"
-      />
+      <FontAwesomeIcon icon={faArrowDown} className="toggle-icon" />
     );
     const { children, title } = this.props;
 
     return (
       <div className={`instruction ${toggleClass}`}>
-        <div className="toggle-header" onClick={() => {
-          this.toggledHandler(!this.state.toggled);
-        }}>
+        <div
+          className="toggle-header"
+          onClick={() => {
+            this.toggledHandler(!this.state.toggled);
+          }}
+        >
           <div>{title}</div>
           <div>{toggleIcon}</div>
         </div>

--- a/src/components/UI/Footer.js
+++ b/src/components/UI/Footer.js
@@ -25,12 +25,24 @@ const Footer = () => {
   return (
     <footer>
       <ul>
-        <li><a href=".">Home</a></li>
-        <li><a href="https://www2.gov.bc.ca/gov/content/home/disclaimer">Disclaimer</a></li>
-        <li><a href="https://www2.gov.bc.ca/gov/content/home/privacy">Privacy</a></li>
-        <li><a href="https://www2.gov.bc.ca/gov/content/home/accessibility">Accessibility</a></li>
-        <li><a href="https://www2.gov.bc.ca/gov/content/home/copyright">Copyright</a></li>
-        <li><a href="https://github.com/bcgov/devhub-signing-web">Contact Us</a></li>
+        <li>
+          <a href=".">Home</a>
+        </li>
+        <li>
+          <a href="https://www2.gov.bc.ca/gov/content/home/disclaimer">Disclaimer</a>
+        </li>
+        <li>
+          <a href="https://www2.gov.bc.ca/gov/content/home/privacy">Privacy</a>
+        </li>
+        <li>
+          <a href="https://www2.gov.bc.ca/gov/content/home/accessibility">Accessibility</a>
+        </li>
+        <li>
+          <a href="https://www2.gov.bc.ca/gov/content/home/copyright">Copyright</a>
+        </li>
+        <li>
+          <a href="https://github.com/bcgov/devhub-signing-web">Contact Us</a>
+        </li>
       </ul>
     </footer>
   );


### PR DESCRIPTION
The 'Steps to Upload Your App' buttons on the signing tool page weren't very intuitive - only the arrow icon was clickable and the cursor did not change when hovering. In this PR, I made the toggle header clickable, enabled pointer when hovering over 'Steps to Upload Your App' buttons, fixed unit tests and added eslint script package.